### PR TITLE
`ComponentInteractionData`: return `APIMessageComponentInteraction` when `ComponentType` is unknown

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -304,7 +304,7 @@ type ComponentType = 'Button' | 'Select' | unknown
 type ComponentInteractionData<T extends ComponentType> =
   T extends 'Button' ? APIMessageComponentButtonInteraction :
   T extends 'Select' ? APIMessageComponentSelectMenuInteraction :
-  APIMessageComponentSelectMenuInteraction
+  APIMessageComponentInteraction
 export class ComponentContext<E extends Env = any, T extends ComponentType = unknown> extends Context235<
   E & { Variables: { custom_id?: string } },
   ComponentInteractionData<T>


### PR DESCRIPTION
Closes #8 
Replaced `APIMessageComponentSelectMenuInteraction` on line 307 of file `src/context.ts` with `APIMessageComponentInteraction`